### PR TITLE
Fix weights table search algorithm to work under different Ruby versions

### DIFF
--- a/lib/uk_account_validator.rb
+++ b/lib/uk_account_validator.rb
@@ -1,3 +1,5 @@
+require 'uk_account_validator/backports/array_bsearch_index'
+
 require 'uk_account_validator/number_indices.rb'
 require 'uk_account_validator/validator.rb'
 require 'uk_account_validator/modulus_weight.rb'

--- a/lib/uk_account_validator/backports/array_bsearch_index.rb
+++ b/lib/uk_account_validator/backports/array_bsearch_index.rb
@@ -1,0 +1,33 @@
+# Copied from backports gem
+unless Array.method_defined? :bsearch_index
+  class Array
+    def bsearch_index
+      return to_enum(__method__) unless block_given?
+      from = 0
+      to   = size - 1
+      satisfied = nil
+      while from <= to do
+        midpoint = (from + to).div(2)
+        result = yield(self[midpoint])
+        case result
+        when Numeric
+          return midpoint if result == 0
+          result = result < 0
+        when true
+          satisfied = midpoint
+        when nil, false
+          # nothing to do
+        else
+          raise TypeError, "wrong argument type #{result.class} (must be numeric, true, false or nil)"
+        end
+
+        if result
+          to = midpoint - 1
+        else
+          from = midpoint + 1
+        end
+      end
+      satisfied
+    end
+  end
+end

--- a/lib/uk_account_validator/modulus_weights_table.rb
+++ b/lib/uk_account_validator/modulus_weights_table.rb
@@ -8,24 +8,28 @@ module UkAccountValidator
         @weights << ModulusWeight.from_line(line)
       end
 
-      @weights.sort! { |weight| weight.sort_code_start.to_i }
+      @weights.sort_by! { |weight| -weight.sort_code_start.to_i }
     end
 
-    def find(sort_code, found_weights = [], exclude = [])
+    def find(sort_code)
       sort_code = sort_code.to_i
 
-      weight = @weights.bsearch do |w|
-        w.sort_code_start.to_i <= sort_code && !exclude.include?(w)
+      min_found_weight_index = @weights.bsearch_index do |w|
+        w.sort_code_start.to_i <= sort_code
       end
 
-      return found_weights if weight.nil?
-      return found_weights unless
-        weight.sort_code_start.to_i <= sort_code &&
-        sort_code <= weight.sort_code_end.to_i
+      return [] if min_found_weight_index.nil?
 
-      found_weights << weight
+      found_weights = []
+      index = min_found_weight_index
+      while index < @weights.size &&
+              @weights[index].sort_code_start.to_i <= sort_code &&
+              sort_code <= @weights[index].sort_code_end.to_i
+        found_weights << @weights[index]
+        index += 1
+      end
 
-      find(sort_code, found_weights, exclude + [weight])
+      found_weights
     end
   end
 end


### PR DESCRIPTION
Original algorithm apparently relied on specific ordering of equal elements
returned by `Array#sort`. However, sorting algorithms in Ruby are
unstable by design, and the ordering may change between Ruby
implementations. This is why there were test failures on Ruby 2.3.0.

This change fixes the algorithm to work regardless of Ruby version,
while also simplifying it by getting rid of unnecessary recursion.

I used `Array#bsearch_with_index` when rewriting the algorithm,
which unfortunately doesn't exist in Ruby < 2.3, so I added a backported
implementation for older Ruby versions, taken from backports gem
(I wanted to avoid pulling in a runtime dependency).